### PR TITLE
Implemented analog encoders to spark max

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -16,6 +16,7 @@ package frc.robot;
 import com.pathplanner.lib.auto.AutoBuilder;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.GenericHID;
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
@@ -465,13 +466,12 @@ public class RobotContainer {
         new AlgaeProcessorCommand(m_superStructure)
             .alongWith(
                 DriveCommands.joystickDriveAtAngle(
-                    m_drive,
-                    () -> -m_driverController.getLeftY(),
-                    () -> -m_driverController.getLeftX(),
-                    () -> -m_driverController.getRightX(),
-                    () -> FieldConstants.getProcessorAngle()))
-        // .unless(() -> DriverStation.isTest()))
-        );
+                        m_drive,
+                        () -> -m_driverController.getLeftY(),
+                        () -> -m_driverController.getLeftX(),
+                        () -> -m_driverController.getRightX(),
+                        () -> FieldConstants.getProcessorAngle())
+                    .unless(() -> DriverStation.isTest())));
     // .onFalse(
     //     new SuperStructureCommand(m_superStructure, () -> SuperStructureState.IDLE)
     //         .alongWith(new ScoreAlgaeCommand(m_endEffector)));

--- a/src/main/java/frc/robot/subsystems/drive/DriveConstants.java
+++ b/src/main/java/frc/robot/subsystems/drive/DriveConstants.java
@@ -42,10 +42,10 @@ public class DriveConstants {
       };
 
   // Zeroed rotation values for each module, see setup instructions
-  public static final Rotation2d kFrontLeftZeroRotation = new Rotation2d(5.844648404296888);
-  public static final Rotation2d kFrontRightZeroRotation = new Rotation2d(0.5623250622059073);
-  public static final Rotation2d kBackLeftZeroRotation = new Rotation2d(3.840143520854242);
-  public static final Rotation2d kBackRightZeroRotation = new Rotation2d(6.124233327397502);
+  public static final Rotation2d kFrontLeftZeroRotation = new Rotation2d(5.745);
+  public static final Rotation2d kFrontRightZeroRotation = new Rotation2d(0.5755);
+  public static final Rotation2d kBackLeftZeroRotation = new Rotation2d(3.785);
+  public static final Rotation2d kBackRightZeroRotation = new Rotation2d(6.1);
 
   // Device CAN IDs
   public static final int kFrontLeftDriveCanId = 13;
@@ -89,7 +89,7 @@ public class DriveConstants {
   public static final double kTurnEncoderVelocityFactor =
       (2 * Math.PI) / 60.0 / kTurnMotorReduction; // Rotor RPM -> Wheel Rad/Sec
   public static final double kTurnAbsoluteEncoderPositionFactor =
-      2 * Math.PI; // Rotations -> Radians
+      2 * Math.PI / 3.3; // 0-3.3V -> Radians
   public static final double kTurnAbsoluteEncoderVelocityFactor =
       (2 * Math.PI) / 60.0; // RPM -> Rad/Sec
 
@@ -106,7 +106,7 @@ public class DriveConstants {
   public static final double kDriveSimKa = 0.020314;
 
   // Turn PID configuration
-  public static final double kTurnKp = 5.5;
+  public static final double kTurnKp = 1.0;
   public static final double kTurnKd = 0.0;
   public static final double kTurnSimP = 8.0;
   public static final double kTurnSimD = 0.0;

--- a/src/main/java/frc/robot/subsystems/drive/DriveConstants.java
+++ b/src/main/java/frc/robot/subsystems/drive/DriveConstants.java
@@ -43,7 +43,7 @@ public class DriveConstants {
 
   // Zeroed rotation values for each module, see setup instructions
   public static final Rotation2d kFrontLeftZeroRotation = new Rotation2d(5.844648404296888);
-  public static final Rotation2d kFrontRightZeroRotation = new Rotation2d(0.5623250622059073);
+  public static final Rotation2d kFrontRightZeroRotation = new Rotation2d(0.5237208604812622);
   public static final Rotation2d kBackLeftZeroRotation = new Rotation2d(3.840143520854242);
   public static final Rotation2d kBackRightZeroRotation = new Rotation2d(6.124233327397502);
 

--- a/src/main/java/frc/robot/subsystems/drive/DriveConstants.java
+++ b/src/main/java/frc/robot/subsystems/drive/DriveConstants.java
@@ -91,7 +91,7 @@ public class DriveConstants {
   public static final double kTurnAbsoluteEncoderPositionFactor =
       2 * Math.PI / 3.3; // 0-3.3V -> Radians
   public static final double kTurnAbsoluteEncoderVelocityFactor =
-      (2 * Math.PI) / 60.0; // RPM -> Rad/Sec
+      kTurnAbsoluteEncoderPositionFactor / 60.0; // RPM -> Rad/Sec
 
   // Drive PID configuration
   public static final double kDriveKp = 0.0;

--- a/src/main/java/frc/robot/subsystems/drive/DriveConstants.java
+++ b/src/main/java/frc/robot/subsystems/drive/DriveConstants.java
@@ -42,10 +42,10 @@ public class DriveConstants {
       };
 
   // Zeroed rotation values for each module, see setup instructions
-  public static final Rotation2d kFrontLeftZeroRotation = new Rotation2d(5.745);
-  public static final Rotation2d kFrontRightZeroRotation = new Rotation2d(0.5755);
-  public static final Rotation2d kBackLeftZeroRotation = new Rotation2d(3.785);
-  public static final Rotation2d kBackRightZeroRotation = new Rotation2d(6.1);
+  public static final Rotation2d kFrontLeftZeroRotation = new Rotation2d(5.844648404296888);
+  public static final Rotation2d kFrontRightZeroRotation = new Rotation2d(0.5623250622059073);
+  public static final Rotation2d kBackLeftZeroRotation = new Rotation2d(3.840143520854242);
+  public static final Rotation2d kBackRightZeroRotation = new Rotation2d(6.124233327397502);
 
   // Device CAN IDs
   public static final int kFrontLeftDriveCanId = 13;

--- a/src/main/java/frc/robot/subsystems/drive/DriveConstants.java
+++ b/src/main/java/frc/robot/subsystems/drive/DriveConstants.java
@@ -106,7 +106,7 @@ public class DriveConstants {
   public static final double kDriveSimKa = 0.020314;
 
   // Turn PID configuration
-  public static final double kTurnKp = 1.0;
+  public static final double kTurnKp = 5.5;
   public static final double kTurnKd = 0.0;
   public static final double kTurnSimP = 8.0;
   public static final double kTurnSimD = 0.0;

--- a/src/main/java/frc/robot/subsystems/drive/Module.java
+++ b/src/main/java/frc/robot/subsystems/drive/Module.java
@@ -141,7 +141,7 @@ public class Module {
   public void runCharacterization(double output) {
     isClosedLoop = false;
     m_io.setDriveOpenLoop(output);
-    m_turnController.setSetpoint(m_io.getZeroRotation().getRadians());
+    m_turnController.setSetpoint(0.0);
     m_io.setTurnOpenLoop(m_turnController.calculate(m_inputs.turnPosition.getRadians()));
   }
 

--- a/src/main/java/frc/robot/subsystems/drive/Module.java
+++ b/src/main/java/frc/robot/subsystems/drive/Module.java
@@ -94,8 +94,7 @@ public class Module {
                 .plus(m_driveFF.calculate(nextDriveR).plus(kDriveKs * Math.signum(driveSetpoint)))
                 .get(0, 0));
 
-        m_io.setTurnOpenLoop(
-            m_turnController.calculate(m_inputs.turnAbsolutePosition.getRadians()));
+        m_io.setTurnOpenLoop(m_turnController.calculate(m_inputs.turnPosition.getRadians()));
       } else {
         m_driveController.reset();
         m_turnController.reset();
@@ -104,8 +103,7 @@ public class Module {
       if (isClosedLoop) {
         m_io.setDriveOpenLoop(
             m_driveFFVolts + m_driveController.calculate(m_inputs.driveVelocityRadPerSec));
-        m_io.setTurnOpenLoop(
-            m_turnController.calculate(m_inputs.turnAbsolutePosition.getRadians()));
+        m_io.setTurnOpenLoop(m_turnController.calculate(m_inputs.turnPosition.getRadians()));
       } else {
         m_driveController.reset();
         m_turnController.reset();
@@ -144,7 +142,7 @@ public class Module {
     isClosedLoop = false;
     m_io.setDriveOpenLoop(output);
     m_turnController.setSetpoint(m_io.getZeroRotation().getRadians());
-    m_io.setTurnOpenLoop(m_turnController.calculate(m_inputs.turnAbsolutePosition.getRadians()));
+    m_io.setTurnOpenLoop(m_turnController.calculate(m_inputs.turnPosition.getRadians()));
   }
 
   public void runTurnCharacterization(double output) {

--- a/src/main/java/frc/robot/subsystems/drive/Module.java
+++ b/src/main/java/frc/robot/subsystems/drive/Module.java
@@ -134,7 +134,7 @@ public class Module {
     double velocityRadPerSec = state.speedMetersPerSecond / kWheelRadiusMeters;
     m_driveFFVolts = kDriveKs * Math.signum(velocityRadPerSec) + kDriveKv * velocityRadPerSec;
     m_driveController.setSetpoint(velocityRadPerSec);
-    m_turnController.setSetpoint(state.angle.plus(m_io.getZeroRotation()).getRadians());
+    m_turnController.setSetpoint(state.angle.getRadians());
   }
 
   /** Runs the module with the specified output while controlling to zero degrees. */

--- a/src/main/java/frc/robot/subsystems/drive/ModuleIO.java
+++ b/src/main/java/frc/robot/subsystems/drive/ModuleIO.java
@@ -45,8 +45,4 @@ public interface ModuleIO {
 
   /** Run the turn motor at the specified open loop value. */
   public default void setTurnOpenLoop(double output) {}
-
-  public default Rotation2d getZeroRotation() {
-    return new Rotation2d();
-  }
 }

--- a/src/main/java/frc/robot/subsystems/drive/ModuleIOSpark.java
+++ b/src/main/java/frc/robot/subsystems/drive/ModuleIOSpark.java
@@ -180,11 +180,11 @@ public class ModuleIOSpark implements ModuleIO {
     ifOk(
         m_turnSpark,
         m_turnEncoder::getPosition,
-        (value) -> inputs.turnPosition = new Rotation2d(value).minus(m_zeroRotation));
+        (value) -> inputs.turnPosition = new Rotation2d(value));
     ifOk(
         m_turnSpark,
         m_turnAbsoluteEncoder::getPosition,
-        (value) -> inputs.turnAbsolutePosition = new Rotation2d(value));
+        (value) -> inputs.turnAbsolutePosition = new Rotation2d(value).minus(m_zeroRotation));
     ifOk(m_turnSpark, m_turnEncoder::getVelocity, (value) -> inputs.turnVelocityRadPerSec = value);
     ifOk(
         m_turnSpark,
@@ -200,7 +200,7 @@ public class ModuleIOSpark implements ModuleIO {
         m_drivePositionQueue.stream().mapToDouble((Double value) -> value).toArray();
     inputs.odometryTurnPositions =
         m_turnPositionQueue.stream()
-            .map((Double value) -> new Rotation2d(value).minus(m_zeroRotation))
+            .map((Double value) -> new Rotation2d(value))
             .toArray(Rotation2d[]::new);
     m_timestampQueue.clear();
     m_drivePositionQueue.clear();
@@ -224,10 +224,5 @@ public class ModuleIOSpark implements ModuleIO {
   @Override
   public void setTurnOpenLoop(double output) {
     m_turnSpark.setVoltage(output);
-  }
-
-  @Override
-  public Rotation2d getZeroRotation() {
-    return m_zeroRotation;
   }
 }

--- a/src/main/java/frc/robot/subsystems/drive/ModuleIOSpark.java
+++ b/src/main/java/frc/robot/subsystems/drive/ModuleIOSpark.java
@@ -17,6 +17,7 @@ import static frc.robot.subsystems.drive.DriveConstants.*;
 import static frc.robot.util.SparkUtil.*;
 
 import com.revrobotics.RelativeEncoder;
+import com.revrobotics.spark.SparkAnalogSensor;
 import com.revrobotics.spark.SparkBase.PersistMode;
 import com.revrobotics.spark.SparkBase.ResetMode;
 import com.revrobotics.spark.SparkLowLevel.MotorType;
@@ -25,7 +26,6 @@ import com.revrobotics.spark.config.SparkBaseConfig.IdleMode;
 import com.revrobotics.spark.config.SparkMaxConfig;
 import edu.wpi.first.math.filter.Debouncer;
 import edu.wpi.first.math.geometry.Rotation2d;
-import edu.wpi.first.wpilibj.AnalogInput;
 import edu.wpi.first.wpilibj.RobotController;
 import java.util.Queue;
 import java.util.function.DoubleSupplier;
@@ -42,7 +42,7 @@ public class ModuleIOSpark implements ModuleIO {
   private final SparkMax m_turnSpark;
   private final RelativeEncoder m_driveEncoder;
   private final RelativeEncoder m_turnEncoder;
-  private final AnalogInput m_turnAbsoluteEncoder;
+  private final SparkAnalogSensor m_turnAbsoluteEncoder;
 
   // Queue inputs from odometry thread
   private final Queue<Double> m_timestampQueue;
@@ -84,15 +84,7 @@ public class ModuleIOSpark implements ModuleIO {
             MotorType.kBrushless);
     m_driveEncoder = m_driveSpark.getEncoder();
     m_turnEncoder = m_turnSpark.getEncoder();
-    m_turnAbsoluteEncoder =
-        new AnalogInput(
-            switch (module) {
-              case 0 -> kFrontLeftAbsoluteEncoderPort;
-              case 1 -> kFrontRightAbsoluteEncoderPort;
-              case 2 -> kBackLeftAbsoluteEncoderPort;
-              case 3 -> kBackRightAbsoluteEncoderPort;
-              default -> 0;
-            });
+    m_turnAbsoluteEncoder = m_turnSpark.getAnalog();
 
     // Configure drive motor
     var driveConfig = new SparkMaxConfig();
@@ -136,6 +128,7 @@ public class ModuleIOSpark implements ModuleIO {
         .velocityConversionFactor(kTurnEncoderVelocityFactor)
         .uvwMeasurementPeriod(10)
         .uvwAverageDepth(2);
+    turnConfig.analogSensor.positionConversionFactor(kTurnAbsoluteEncoderPositionFactor);
     turnConfig
         .signals
         .primaryEncoderPositionAlwaysOn(true)
@@ -191,11 +184,11 @@ public class ModuleIOSpark implements ModuleIO {
         m_turnSpark,
         m_turnEncoder::getPosition,
         (value) -> inputs.turnPosition = new Rotation2d(value).minus(m_zeroRotation));
-    inputs.turnAbsolutePosition =
-        new Rotation2d(
-            m_turnAbsoluteEncoder.getVoltage()
-                / RobotController.getVoltage5V()
-                * kTurnAbsoluteEncoderPositionFactor);
+    ifOk(
+        m_turnSpark,
+        m_turnAbsoluteEncoder::getPosition,
+        (value) -> inputs.turnAbsolutePosition = new Rotation2d(value));
+    inputs.turnAbsolutePosition = new Rotation2d(m_turnAbsoluteEncoder.getPosition());
     ifOk(m_turnSpark, m_turnEncoder::getVelocity, (value) -> inputs.turnVelocityRadPerSec = value);
     ifOk(
         m_turnSpark,

--- a/src/main/java/frc/robot/subsystems/drive/ModuleIOSpark.java
+++ b/src/main/java/frc/robot/subsystems/drive/ModuleIOSpark.java
@@ -16,6 +16,7 @@ package frc.robot.subsystems.drive;
 import static frc.robot.subsystems.drive.DriveConstants.*;
 import static frc.robot.util.SparkUtil.*;
 
+import com.revrobotics.REVLibError;
 import com.revrobotics.RelativeEncoder;
 import com.revrobotics.spark.SparkAnalogSensor;
 import com.revrobotics.spark.SparkBase.PersistMode;
@@ -207,12 +208,11 @@ public class ModuleIOSpark implements ModuleIO {
     m_turnPositionQueue.clear();
 
     // Reset neo relative encoder using absolute encoder position
-    if (!m_turnEncoderInitialized) {
-      m_turnEncoderInitialized = true;
-      tryUntilOk(
-          m_turnSpark,
-          5,
-          () -> m_turnEncoder.setPosition(inputs.turnAbsolutePosition.getRadians()));
+    if (!m_turnEncoderInitialized && !inputs.turnAbsolutePosition.equals(new Rotation2d())) {
+      REVLibError result = m_turnEncoder.setPosition(inputs.turnAbsolutePosition.getRadians());
+      if (result == REVLibError.kOk) {
+        m_turnEncoderInitialized = true;
+      }
     }
   }
 

--- a/src/main/java/frc/robot/subsystems/drive/ModuleIOSpark.java
+++ b/src/main/java/frc/robot/subsystems/drive/ModuleIOSpark.java
@@ -148,8 +148,9 @@ public class ModuleIOSpark implements ModuleIO {
             m_turnSpark.configure(
                 turnConfig, ResetMode.kResetSafeParameters, PersistMode.kPersistParameters));
     // Reset neo relative encoder using absolute encoder position
-    tryUntilOk(
-        m_turnSpark, 5, () -> m_turnEncoder.setPosition(m_turnAbsoluteEncoder.getPosition()));
+    double[] turnAbsPos = new double[1];
+    ifOk(m_turnSpark, m_turnAbsoluteEncoder::getPosition, (value) -> turnAbsPos[0] = value);
+    tryUntilOk(m_turnSpark, 5, () -> m_turnEncoder.setPosition(turnAbsPos[0]));
 
     // Create odometry queues
     m_timestampQueue = SparkOdometryThread.getInstance().makeTimestampQueue();


### PR DESCRIPTION
Rewrote swerve code to use analog encoder adapter boards for the spark max
Swerve now only uses absolute encoders to reset relative encoders at startup
Some other optimizations